### PR TITLE
Added 2 features sourcePath & rootNodeRef

### DIFF
--- a/amp/src/main/java/org/alfresco/extension/bulkimport/source/fs/FilesystemBulkImportItemVersion.java
+++ b/amp/src/main/java/org/alfresco/extension/bulkimport/source/fs/FilesystemBulkImportItemVersion.java
@@ -91,6 +91,18 @@ public final class FilesystemBulkImportItemVersion
         this.contentReference       = contentFile;
         this.metadataReference      = metadataFile;
 
+        
+        // mru : set the correct content file reference based on metadata
+        if (contentFile == null) 
+        {
+        	Map<String,Serializable> metadataMap = getMetadata();
+            if (metadataMap.containsKey("sourcePath")) 
+            {
+            	String path = (String)metadataMap.get("sourcePath");
+            	this.contentReference = new File(path);
+            }
+        }
+        
         // "stat" the content file then cache the results
         this.isDirectory = serviceRegistry.getDictionaryService().isSubClass(createQName(serviceRegistry, getType()), ContentModel.TYPE_FOLDER);
                 

--- a/core/build.properties
+++ b/core/build.properties
@@ -1,0 +1,11 @@
+#Mon, 22 Sep 2014 16:38:10 +0200
+#Thu Dec 08 17:19:17 CET 2011
+repo.admin.username=admin
+share.scripts.index=http\://localhost\:8081/share/service/index
+alfresco.scripts.index=http\://localhost\:8080/alfresco/service/index
+repo.admin.password=admin
+tomcat_share.dir=/D\:/Alfresco/tomcat_share
+tomcat_alfresco.dir=/D\:/Alfresco/tomcat
+#tomcat_share.dir=/opt/alfresco-4.2.f/tomcat
+#tomcat_alfresco.dir=/opt/alfresco-4.2.f/tomcat
+#alfresco.sdk.dir=C\:/Projecten/Alfresco/SDK/alfresco-enterprise-sdk-4.0.2/lib/server

--- a/core/build.xml
+++ b/core/build.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0"?>
+
+<project name="alfresco-bulk-import" default="deploy" basedir=".">
+	<property file="build.properties" />
+
+	<!-- Build properties -->
+	<property name="project.dir" value="." />
+	<property name="dist.dir" value="${project.dir}/dist" />
+	<property name="bin.dir" value="${project.dir}/target/classes" />
+	<property name="web.dir" value="${project.dir}/src/main/amp/web" />
+	<property name="sources.dir" value="${project.dir}/src/java" />
+	<property name="resources.dir" value="${project.dir}/src/main/amp/config" />
+	<property name="properties.dir" value="${project.dir}/src/properties" />
+	<property name="version" value="0.1.0" />
+	<property name="jar.name" value="${ant.project.name}-${version}.${sprint}.${build}" />
+	<property name="tomcat.dir" value="Tomcat Dir" />
+
+	<taskdef name="http" classname="org.missinglink.ant.task.http.HttpClientTask">
+	</taskdef>
+
+	<!-- Deploy to Tomcat instance -->
+	<target name="deploy">
+		<copy todir="${tomcat_alfresco.dir}/shared/classes/alfresco/extension">
+			<fileset dir="${resources.dir}/alfresco/extension">
+				<include name="**" />
+			</fileset>
+		</copy>
+		<copy todir="${tomcat_alfresco.dir}/webapps/alfresco/WEB-INF/classes/alfresco/module">
+			<fileset dir="${resources.dir}/alfresco/module">
+				<include name="**" />
+			</fileset>
+		</copy>
+		<copy todir="${tomcat_alfresco.dir}/webapps/alfresco/WEB-INF/classes">
+			<fileset dir="${bin.dir}">
+				<include name="**" />
+			</fileset>
+		</copy>
+		<copy todir="${tomcat_alfresco.dir}/webapps/alfresco">
+			<fileset dir="${web.dir}">
+				<include name="**" />
+			</fileset>
+		</copy>
+	</target>
+
+	<!-- Build the JAR file -->
+	<target name="dist-jar" description="Build a JAR file containing configuration and resource files">
+		<jar destfile="${dist.dir}/${jar.name}-shared.jar">
+			<zipfileset dir="${web.dir}" prefix="META-INF" />
+			<fileset dir="${resources.dir}">
+				<exclude name="alfresco/web-extension/share-config-custom.xml" />
+				<exclude name="alfresco/extension/dev-log4j.properties" />
+			</fileset>
+		</jar>
+		<jar destfile="${dist.dir}/${jar.name}-src.jar">
+			<fileset dir="${bin.dir}" />
+			<modified />
+		</jar>
+	</target>
+
+	<target name="reload-webscripts-alfresco" depends="deploy" description="Reload Share webscripts">
+		<http url="${alfresco.scripts.index}" method="POST" printrequest="false" printrequestheaders="false" printresponse="false" printresponseheaders="false" expected="200" failonunexpected="true">
+			<credentials username="${repo.admin.username}" password="${repo.admin.password}" />
+			<query>
+				<parameter name="reset" value="on" />
+			</query>
+		</http>
+	</target>
+
+</project>

--- a/core/src/main/amp/module.properties
+++ b/core/src/main/amp/module.properties
@@ -1,0 +1,6 @@
+module.id=org.alfresco.extension.alfresco-bulk-import
+module.version=1.99.99
+module.title=Alfresco Bulk Import v2.0-SNAPSHOT (for Alfresco v5.0+)
+module.description=Alfresco Bulk Import tool. Provides high performance bulk loading of content into Alfresco.
+module.repo.version.min=4.2.0
+module.repo.version.max=5.99.99

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
       <dependency>
         <groupId>${alfresco.groupId}</groupId>
         <artifactId>alfresco-platform-distribution</artifactId>
-        <version>${alfresco.version}</version>
+        <version>4.2.e</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
       <dependency>
         <groupId>${alfresco.groupId}</groupId>
         <artifactId>alfresco-platform-distribution</artifactId>
-        <version>4.2.e</version>
+        <version>${alfresco.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
So after a lot of time finally we created these 2 features:
1. SourcePath. In a big migration where more then couple of TB needs to be imported it's not feasible to move the source content next to the XML you've probably created.
So we (Contezza) created a fix to an optional extra entry key can be supplied.
`<entry key="sourcePath">D:\temp\files\Doc1.pdf</entry>`
2. RootNodeRef. To create the 'exact' folders on disk is a hassle in most cases. These folder structure are in some cases enormous or complex to create and will have a lot of overhead.
 A path can be supplied and the code will find or create the structure.
`<entry key="rootNodeRef">/Company Home/Sites/test/documentLibrary/Bulk</entry>`
